### PR TITLE
[Broken] Exclude generated code from formatting

### DIFF
--- a/tests/commonmark.rs
+++ b/tests/commonmark.rs
@@ -18,6 +18,7 @@ fn run(input: &str, output: &str) {
 
 ///////////////////////////////////////////////////////////////////////////
 // TESTGEN: fixtures/commonmark/good.txt
+#[rustfmt::skip]
 mod fixtures_commonmark_good_txt {
 use super::run;
 // this part of the file is auto-generated

--- a/tests/fixtures/testgen.js
+++ b/tests/fixtures/testgen.js
@@ -72,6 +72,7 @@ for (let line of input.split('\n')) {
             let match = line.match(/^\/{2,}\s+TESTGEN:\s*(.+)\s*$/)
             if (match) {
                 let has_data = false
+                lines.push('#[rustfmt::skip]')
                 lines.push(`mod ${ident(match[1])} {`)
                 lines.push('use super::run;')
                 lines.push('// this part of the file is auto-generated')

--- a/tests/markdown-it.rs
+++ b/tests/markdown-it.rs
@@ -19,6 +19,7 @@ fn run(input: &str, output: &str) {
 
 ///////////////////////////////////////////////////////////////////////////
 // TESTGEN: fixtures/markdown-it/tables.txt
+#[rustfmt::skip]
 mod fixtures_markdown_it_tables_txt {
 use super::run;
 // this part of the file is auto-generated
@@ -748,7 +749,7 @@ fn gfm_4_10_tables_extension_example_203() {
 | --- |
 | bar |"#;
     let output = r#"<p>| abc | def |
-| --- |
+| — |
 | bar |</p>"#;
     run(input, output);
 }


### PR DESCRIPTION
Hi,
I'm currently using markdown-it.rs as a base to build a rust port of the [ssb-markdown](https://github.com/ssbc/ssb-markdown/) module. Kind of as a learning exercise. Suffice it to say I've learned much more about Unicode and Emojis than anything else. 🙈 
In any case, thanks for this library! I've found it quite pleasant to work with and hadn't seen the need to modify the library as such, so far. 

One thing I'm attempting right now is to port more of the markdown-it test suite, to reproduce more of the custom formatting. For example I think that smartypants typography (smart quotes and such) might be generally useful enough to be included in this library? Even if not, I can worry about breaking such things into separate files later.

To the actual topic here:

My first order of the day was to do `cargo fmt` because my IDE is set up to use it on save and I didn't want to litter the commit logs with half-formatted things. So I modified `testgen.js` 
to include a `#[rustfmt::skip]` call before each test mode, such that the auto-generated code wouldn't be subject to formatting and everyone could be happy. Re-generating the code for `common-mark.rs` worked like a charm, you can see that it only added the `#[rustfmt::skip]` line. For `markdown-it.rs` however there seems to have been some other issue; there is another change being generated and indeed that test now fails.

Any idea why this might happen? 