### PR TITLE
Typographer (Replacing ©, ®, ™, ... etc)

### DIFF
--- a/src/plugins/cmark/inline/autolink.rs
+++ b/src/plugins/cmark/inline/autolink.rs
@@ -6,7 +6,7 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 use crate::{MarkdownIt, Node, NodeValue, Renderer};
-use crate::parser::inline::{InlineRule, InlineState, Text};
+use crate::parser::inline::{InlineRule, InlineState, TextSpecial};
 
 #[derive(Debug)]
 pub struct Autolink {
@@ -71,7 +71,11 @@ impl InlineRule for AutolinkScanner {
 
         let content = state.md.link_formatter.normalize_link_text(url);
 
-        let mut inner_node = Node::new(Text { content });
+        let mut inner_node = Node::new(TextSpecial {
+            content: content.clone(),
+            markup: content,
+            info: "autolink",
+        });
         inner_node.srcmap = state.get_map(state.pos + 1, pos - 1);
 
         let mut node = Node::new(Autolink { url: full_url });

--- a/src/plugins/extra/linkify.rs
+++ b/src/plugins/extra/linkify.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use crate::parser::core::{CoreRule, Root};
 use crate::parser::extset::RootExt;
 use crate::parser::inline::builtin::InlineParserRule;
-use crate::parser::inline::{InlineRule, InlineState, Text};
+use crate::parser::inline::{InlineRule, InlineState, TextSpecial};
 use crate::{MarkdownIt, Node, NodeValue, Renderer};
 
 static SCHEME_RE : Lazy<Regex> = Lazy::new(|| {
@@ -117,7 +117,11 @@ impl InlineRule for LinkifyScanner {
 
         let content = state.md.link_formatter.normalize_link_text(url);
 
-        let mut inner_node = Node::new(Text { content });
+        let mut inner_node = Node::new(TextSpecial {
+            content: content.clone(),
+            markup: content,
+            info: "autolink",
+        });
         inner_node.srcmap = state.get_map(url_start, url_end);
 
         let mut node = Node::new(Linkified { url: full_url });

--- a/src/plugins/extra/mod.rs
+++ b/src/plugins/extra/mod.rs
@@ -17,6 +17,7 @@ pub mod beautify_links;
 pub mod linkify;
 #[cfg(feature = "syntect")]
 pub mod syntect;
+pub mod typographer;
 
 use crate::MarkdownIt;
 

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -36,6 +36,8 @@ fn get_replacements() -> &'static Box<[(Regex, &'static str)]> {
             (Regex::new(r"\+-").unwrap(), "±"),
             (Regex::new(r"\.{2,}").unwrap(), "…"),
             (Regex::new(r"([?!])…").unwrap(), "$1.."),
+            (Regex::new(r"([?!]){4,}").unwrap(), "$1$1$1"),
+            (Regex::new(r",{2,}").unwrap(), ","),
         ])
     })
 }

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -1,4 +1,35 @@
 //! Common textual replacements for dashes, ©, ™, …
+//!
+//! **Note:** Since this plugin is most useful with smart-quotes, which is not
+//! currently implemented, this plugin is _not_ enabled by default when using
+//! `plugins::extra::add`. You will have to enable it separately:
+//!
+//! ```rust
+//! let md = &mut markdown_it::MarkdownIt::new();
+//! markdown_it::plugins::cmark::add(md);
+//! markdown_it::plugins::extra::add(md);
+//! markdown_it::plugins::extra::typographer::add(md);
+//!
+//! let html = md.parse("Hello world!.... This is the Right Way(TM) to markdown!!!!!").render();
+//! assert_eq!(html.trim(), r#"<p>Hello world!.. This is the Right Way™ to markdown!!!</p>"#);
+//! ```
+//! In summary, these are the replacements that will be made when using this:
+//!
+//! ## Typography
+//!
+//! - Repeated dots (`...`) to ellipsis (`…`)
+//!   except `?...` and `!...` which become `?..` and `!..` respectively
+//! - `+-` to `±`
+//! - Don't repeat `?` and `!` more than 3 times: `???`
+//! - De-duplicate commas
+//! - em and en dashes: `--` to `–` and `---` to `—`
+//!
+//! ## Common symbols (case insensitive)
+//!
+//! - Copyright: `(c)` to `©`
+//! - Reserved: `(r)` to `®`
+//! - Trademark: `(tm)` to `™`
+
 use crate::parser::core::CoreRule;
 use crate::parser::inline::Text;
 use crate::{MarkdownIt, Node};

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -31,5 +31,11 @@ impl CoreRule for TypographerRule {
 }
 
 fn get_replacements() -> &'static Box<[(Regex, &'static str)]> {
-    REPLACEMENTS.get_or_init(|| Box::new([(Regex::new(r"\+-").unwrap(), "±")]))
+    REPLACEMENTS.get_or_init(|| {
+        Box::new([
+            (Regex::new(r"\+-").unwrap(), "±"),
+            (Regex::new(r"\.{2,}").unwrap(), "…"),
+            (Regex::new(r"([?!])…").unwrap(), "$1.."),
+        ])
+    })
 }

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -1,0 +1,17 @@
+//! Common textual replacements for dashes, ©, ™, …
+use crate::parser::core::CoreRule;
+use crate::parser::inline::Text;
+use crate::{MarkdownIt, Node};
+
+pub fn add(md: &mut MarkdownIt) {
+    md.add_rule::<TypographerRule>();
+}
+
+pub struct TypographerRule;
+impl CoreRule for TypographerRule {
+    fn run(root: &mut Node, _: &MarkdownIt) {
+        root.walk_mut(|node, _| {
+            let content = node.cast::<Text>();
+        });
+    }
+}

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -3,6 +3,11 @@ use crate::parser::core::CoreRule;
 use crate::parser::inline::Text;
 use crate::{MarkdownIt, Node};
 
+use once_cell::sync::OnceCell;
+use regex::Regex;
+
+static REPLACEMENTS: OnceCell<Box<[(Regex, &'static str)]>> = OnceCell::new();
+
 pub fn add(md: &mut MarkdownIt) {
     md.add_rule::<TypographerRule>();
 }
@@ -11,7 +16,20 @@ pub struct TypographerRule;
 impl CoreRule for TypographerRule {
     fn run(root: &mut Node, _: &MarkdownIt) {
         root.walk_mut(|node, _| {
-            let content = node.cast::<Text>();
+            let content = node.cast_mut::<Text>();
+            if let Some(mut text_node) = content {
+                let mut result = text_node.content.to_owned();
+                for (pattern, replacement) in get_replacements().iter() {
+                    result = pattern
+                        .replace_all(&result, replacement.to_string())
+                        .to_string();
+                }
+                text_node.content = result;
+            }
         });
     }
+}
+
+fn get_replacements() -> &'static Box<[(Regex, &'static str)]> {
+    REPLACEMENTS.get_or_init(|| Box::new([(Regex::new(r"\+-").unwrap(), "±")]))
 }

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -20,9 +20,24 @@ impl CoreRule for TypographerRule {
             if let Some(mut text_node) = content {
                 let mut result = text_node.content.to_owned();
                 for (pattern, replacement) in get_replacements().iter() {
-                    result = pattern
-                        .replace_all(&result, replacement.to_string())
-                        .to_string();
+                    // This is a bit unfortunate, but since we can't use
+                    // look-ahead and look-behind patterns in the dash
+                    // replacements, the preceding and following characters (pre
+                    // and post in the patterns) become part of the match.
+                    // So a string like "bla-- --foo" would create two
+                    // *overlapping* matches, "a-- " and " --f". But replace_all
+                    // only replaces non-overlapping matches. So we can't do
+                    // this in one single replacement.
+                    // My only consolation here is that this won't happen very
+                    // often in practice, and in any case it's probably good to
+                    // ask whether the patterns match before attempting any
+                    // replacement, since that's supposed to be the cheaper
+                    // operation.
+                    while pattern.is_match(&result) {
+                        result = pattern
+                            .replace_all(&result, replacement.to_string())
+                            .to_string();
+                    }
                 }
                 text_node.content = result;
             }
@@ -38,6 +53,20 @@ fn get_replacements() -> &'static Box<[(Regex, &'static str)]> {
             (Regex::new(r"([?!])…").unwrap(), "$1.."),
             (Regex::new(r"([?!]){4,}").unwrap(), "$1$1$1"),
             (Regex::new(r",{2,}").unwrap(), ","),
+            // These look a little different from the JS implementation because the
+            // regex crate doesn't support look-behind and look-ahead patterns
+            (
+                Regex::new(r"(?m)(?P<pre>^|[^-])(?P<dash>---)(?P<post>[^-]|$)").unwrap(),
+                "$pre\u{2014}$post",
+            ),
+            (
+                Regex::new(r"(?m)(?P<pre>^|\s)(?P<dash>--)(?P<post>\s|$)").unwrap(),
+                "$pre\u{2013}$post",
+            ),
+            (
+                Regex::new(r"(?m)(?P<pre>^|[^-\s])(?P<dash>--)(?P<post>[^-\s]|$)").unwrap(),
+                "$pre\u{2013}$post",
+            ),
         ])
     })
 }

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -7,39 +7,60 @@ use once_cell::sync::OnceCell;
 use regex::Regex;
 
 static REPLACEMENTS: OnceCell<Box<[(Regex, &'static str)]>> = OnceCell::new();
+static SCOPED_RE: OnceCell<Regex> = OnceCell::new();
+static RARE_RE: OnceCell<Regex> = OnceCell::new();
+
+fn replace_abbreviation(input: &str) -> &'static str {
+    match input.to_lowercase().as_str() {
+        "(c)" => "©",
+        "(r)" => "®",
+        "(tm)" => "™",
+        _ => unreachable!("Got invalid abbreviation '{}'", input),
+    }
+}
 
 pub fn add(md: &mut MarkdownIt) {
     md.add_rule::<TypographerRule>();
 }
 
 pub struct TypographerRule;
+
 impl CoreRule for TypographerRule {
     fn run(root: &mut Node, _: &MarkdownIt) {
         root.walk_mut(|node, _| {
-            let content = node.cast_mut::<Text>();
-            if let Some(mut text_node) = content {
-                let mut result = text_node.content.to_owned();
-                for (pattern, replacement) in get_replacements().iter() {
-                    // This is a bit unfortunate, but since we can't use
-                    // look-ahead and look-behind patterns in the dash
-                    // replacements, the preceding and following characters (pre
-                    // and post in the patterns) become part of the match.
-                    // So a string like "bla-- --foo" would create two
-                    // *overlapping* matches, "a-- " and " --f". But replace_all
-                    // only replaces non-overlapping matches. So we can't do
-                    // this in one single replacement.
-                    // My only consolation here is that this won't happen very
-                    // often in practice, and in any case it's probably good to
-                    // ask whether the patterns match before attempting any
-                    // replacement, since that's supposed to be the cheaper
-                    // operation.
-                    while pattern.is_match(&result) {
-                        result = pattern
-                            .replace_all(&result, replacement.to_string())
-                            .to_string();
-                    }
+            if let Some(mut text_node) = node.cast_mut::<Text>() {
+                let scoped_re = get_scoped_re();
+                if scoped_re.is_match(&text_node.content) {
+                    text_node.content = scoped_re
+                        .replace_all(&text_node.content, |caps: &regex::Captures| {
+                            replace_abbreviation(caps.get(0).unwrap().as_str())
+                        })
+                        .to_string();
                 }
-                text_node.content = result;
+                if get_rare_re().is_match(&text_node.content) {
+                    let mut result = text_node.content.to_owned();
+                    for (pattern, replacement) in get_replacements().iter() {
+                        // This is a bit unfortunate, but since we can't use
+                        // look-ahead and look-behind patterns in the dash
+                        // replacements, the preceding and following characters (pre
+                        // and post in the patterns) become part of the match.
+                        // So a string like "bla-- --foo" would create two
+                        // *overlapping* matches, "a-- " and " --f". But replace_all
+                        // only replaces non-overlapping matches. So we can't do
+                        // this in one single replacement.
+                        // My only consolation here is that this won't happen very
+                        // often in practice, and in any case it's probably good to
+                        // ask whether the patterns match before attempting any
+                        // replacement, since that's supposed to be the cheaper
+                        // operation.
+                        while pattern.is_match(&result) {
+                            result = pattern
+                                .replace_all(&result, replacement.to_string())
+                                .to_string();
+                        }
+                    }
+                    text_node.content = result;
+                }
             }
         });
     }
@@ -69,4 +90,12 @@ fn get_replacements() -> &'static Box<[(Regex, &'static str)]> {
             ),
         ])
     })
+}
+
+fn get_scoped_re() -> &'static Regex {
+    SCOPED_RE.get_or_init(|| Regex::new(r"(?i)\((c|tm|r)\)").unwrap())
+}
+
+fn get_rare_re() -> &'static Regex {
+    RARE_RE.get_or_init(|| Regex::new(r"\+-|\.\.|\?\?\?\?|!!!!|,,|--").unwrap())
 }

--- a/tests/fixtures/markdown-it/typographer-extra.txt
+++ b/tests/fixtures/markdown-it/typographer-extra.txt
@@ -1,0 +1,6 @@
+don't touch text in autolinks
+.
+URL with (C) (c) (R) (r) (TM) (tm): https://example.com/(c)(r)(tm)/(C)(R)(TM) what do you think?
+.
+<p>URL with © © ® ® ™ ™: <a href="https://example.com/(c)(r)(tm)/(C)(R)(TM)">https://example.com/(c)(r)(tm)/(C)(R)(TM)</a> what do you think?</p>
+.

--- a/tests/fixtures/markdown-it/typographer-extra.txt
+++ b/tests/fixtures/markdown-it/typographer-extra.txt
@@ -4,3 +4,11 @@ URL with (C) (c) (R) (r) (TM) (tm): https://example.com/(c)(r)(tm)/(C)(R)(TM) wh
 .
 <p>URL with © © ® ® ™ ™: <a href="https://example.com/(c)(r)(tm)/(C)(R)(TM)">https://example.com/(c)(r)(tm)/(C)(R)(TM)</a> what do you think?</p>
 .
+
+
+replacements for TM should allow mixed case tM and Tm
+.
+These two should both end up the same as (TM) and (tm): (tM), (Tm).
+.
+<p>These two should both end up the same as ™ and ™: ™, ™.</p>
+.

--- a/tests/fixtures/markdown-it/typographer.txt
+++ b/tests/fixtures/markdown-it/typographer.txt
@@ -1,0 +1,110 @@
+.
+(bad)
+.
+<p>(bad)</p>
+.
+
+
+copyright
+.
+(c) (C)
+.
+<p>© ©</p>
+.
+
+
+reserved
+.
+(r) (R)
+.
+<p>® ®</p>
+.
+
+
+trademark
+.
+(tm) (TM)
+.
+<p>™ ™</p>
+.
+
+
+plus-minus
+.
++-5
+.
+<p>±5</p>
+.
+
+
+ellipsis
+.
+test.. test... test..... test?..... test!....
+.
+<p>test… test… test… test?.. test!..</p>
+.
+
+
+dupes
+.
+!!!!!! ???? ,,
+.
+<p>!!! ??? ,</p>
+.
+
+copyright should be escapable
+.
+\(c)
+.
+<p>(c)</p>
+.
+
+shouldn't replace entities
+.
+&#40;c) (c&#41; (c)
+.
+<p>(c) (c) ©</p>
+.
+
+
+dashes
+.
+---markdownit --- super---
+
+markdownit---awesome
+
+abc ----
+
+--markdownit -- super--
+
+markdownit--awesome
+.
+<p>—markdownit — super—</p>
+<p>markdownit—awesome</p>
+<p>abc ----</p>
+<p>–markdownit – super–</p>
+<p>markdownit–awesome</p>
+.
+
+dashes should be escapable
+.
+foo \-- bar
+
+foo -\- bar
+.
+<p>foo -- bar</p>
+<p>foo -- bar</p>
+.
+
+regression tests for #624
+.
+1---2---3
+
+1--2--3
+
+1 -- -- 3
+.
+<p>1—2—3</p>
+<p>1–2–3</p>
+<p>1 – – 3</p>
+.

--- a/tests/fixtures/testgen.js
+++ b/tests/fixtures/testgen.js
@@ -72,6 +72,7 @@ for (let line of input.split('\n')) {
             let match = line.match(/^\/{2,}\s+TESTGEN:\s*(.+)\s*$/)
             if (match) {
                 let has_data = false
+                lines.push('#[rustfmt::skip]')
                 lines.push(`mod ${ident(match[1])} {`)
                 lines.push('use super::run;')
                 lines.push('// this part of the file is auto-generated')

--- a/tests/markdown-it-typographer.rs
+++ b/tests/markdown-it-typographer.rs
@@ -1,0 +1,135 @@
+fn run(input: &str, output: &str) {
+    let output = if output.is_empty() {
+        "".to_owned()
+    } else {
+        output.to_owned() + "\n"
+    };
+    let md = &mut markdown_it::MarkdownIt::new();
+    markdown_it::plugins::cmark::add(md);
+    markdown_it::plugins::html::add(md);
+    markdown_it::plugins::extra::typographer::add(md);
+    let node = md.parse(&(input.to_owned() + "\n"));
+
+    // make sure we have sourcemaps for everything
+    node.walk(|node, _| assert!(node.srcmap.is_some()));
+
+    let result = node.render();
+    assert_eq!(result, output);
+
+    // make sure it doesn't crash without trailing \n
+    let _ = md.parse(input.trim_end());
+}
+
+///////////////////////////////////////////////////////////////////////////
+// TESTGEN: fixtures/markdown-it/typographer.txt
+#[rustfmt::skip]
+mod fixtures_markdown_it_typographer_txt {
+use super::run;
+// this part of the file is auto-generated
+// don't edit it, otherwise your changes might be lost
+#[test]
+fn unnamed() {
+    let input = r#"(bad)"#;
+    let output = r#"<p>(bad)</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn copyright() {
+    let input = r#"(c) (C)"#;
+    let output = r#"<p>© ©</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn reserved() {
+    let input = r#"(r) (R)"#;
+    let output = r#"<p>® ®</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn trademark() {
+    let input = r#"(tm) (TM)"#;
+    let output = r#"<p>™ ™</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn plus_minus() {
+    let input = r#"+-5"#;
+    let output = r#"<p>±5</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn ellipsis() {
+    let input = r#"test.. test... test..... test?..... test!...."#;
+    let output = r#"<p>test… test… test… test?.. test!..</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn dupes() {
+    let input = r#"!!!!!! ???? ,,"#;
+    let output = r#"<p>!!! ??? ,</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn copyright_should_be_escapable() {
+    let input = r#"\(c)"#;
+    let output = r#"<p>(c)</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn shouldn_t_replace_entities() {
+    let input = r#"&#40;c) (c&#41; (c)"#;
+    let output = r#"<p>(c) (c) ©</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn dashes() {
+    let input = r#"---markdownit --- super---
+
+markdownit---awesome
+
+abc ----
+
+--markdownit -- super--
+
+markdownit--awesome"#;
+    let output = r#"<p>—markdownit — super—</p>
+<p>markdownit—awesome</p>
+<p>abc ----</p>
+<p>–markdownit – super–</p>
+<p>markdownit–awesome</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn dashes_should_be_escapable() {
+    let input = r#"foo \-- bar
+
+foo -\- bar"#;
+    let output = r#"<p>foo -- bar</p>
+<p>foo -- bar</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn regression_tests_for_624() {
+    let input = r#"1---2---3
+
+1--2--3
+
+1 -- -- 3"#;
+    let output = r#"<p>1—2—3</p>
+<p>1–2–3</p>
+<p>1 – – 3</p>"#;
+    run(input, output);
+}
+// end of auto-generated module
+}

--- a/tests/markdown-it-typographer.rs
+++ b/tests/markdown-it-typographer.rs
@@ -33,6 +33,13 @@ fn don_t_touch_text_in_autolinks() {
     let output = r#"<p>URL with © © ® ® ™ ™: <a href="https://example.com/(c)(r)(tm)/(C)(R)(TM)">https://example.com/(c)(r)(tm)/(C)(R)(TM)</a> what do you think?</p>"#;
     run(input, output);
 }
+
+#[test]
+fn replacements_for_tm_should_allow_mixed_case_tm_and_tm() {
+    let input = r#"These two should both end up the same as (TM) and (tm): (tM), (Tm)."#;
+    let output = r#"<p>These two should both end up the same as ™ and ™: ™, ™.</p>"#;
+    run(input, output);
+}
 // end of auto-generated module
 }
 ///////////////////////////////////////////////////////////////////////////

--- a/tests/markdown-it-typographer.rs
+++ b/tests/markdown-it-typographer.rs
@@ -7,6 +7,7 @@ fn run(input: &str, output: &str) {
     let md = &mut markdown_it::MarkdownIt::new();
     markdown_it::plugins::cmark::add(md);
     markdown_it::plugins::html::add(md);
+    markdown_it::plugins::extra::linkify::add(md);
     markdown_it::plugins::extra::typographer::add(md);
     let node = md.parse(&(input.to_owned() + "\n"));
 
@@ -19,7 +20,21 @@ fn run(input: &str, output: &str) {
     // make sure it doesn't crash without trailing \n
     let _ = md.parse(input.trim_end());
 }
-
+///////////////////////////////////////////////////////////////////////////
+// TESTGEN: fixtures/markdown-it/typographer-extra.txt
+#[rustfmt::skip]
+mod fixtures_markdown_it_typographer_extra_txt {
+use super::run;
+// this part of the file is auto-generated
+// don't edit it, otherwise your changes might be lost
+#[test]
+fn don_t_touch_text_in_autolinks() {
+    let input = r#"URL with (C) (c) (R) (r) (TM) (tm): https://example.com/(c)(r)(tm)/(C)(R)(TM) what do you think?"#;
+    let output = r#"<p>URL with © © ® ® ™ ™: <a href="https://example.com/(c)(r)(tm)/(C)(R)(TM)">https://example.com/(c)(r)(tm)/(C)(R)(TM)</a> what do you think?</p>"#;
+    run(input, output);
+}
+// end of auto-generated module
+}
 ///////////////////////////////////////////////////////////////////////////
 // TESTGEN: fixtures/markdown-it/typographer.txt
 #[rustfmt::skip]


### PR DESCRIPTION
This is a straight-up re-implementation of `lib/rules_core/replacements.js` from the JS library.

There are still a few corner cases I'm not sure about, but this is progressed enough that I'd like feedback if anyone is willing to give. 🙂

I'm especially unsure about the `linkify.rs` modification. I needed this because the JS implementation checks for auto-linkified links, and doesn't touch the text in those. I tried multiple ways to do this.

The "easiest" would have been to be able to walk up the tree of nodes, to determine whether one of my parents is `Linkified`. We don't have that though, right?

The next attempt was to modify `walk_mut` so that I could pass a second closure that would be called when exiting the node. That way I could keep track of the linkification status, similar to how the JS lib does it. However, I never managed to get this past the borrow checker, because I was using a single `linkification_level: i32` which I needed to `mut`-pass to both the entry and exit closure. It might well be that there would be a trivial fix for this (I'm still quite new to Rust and my stdlib-foo is not great) but in any case that would mean a bunch of boiler-plate to insert into all four `walk[_post][_mut]` methods and everywhere they're used.

So my solution is to attach an empty `LinkifyMarker` struct to the nodes when they get auto-linkified. I then just check if the text node I'm dealing with has that marker, and ignore it if it's the case. 

Side note: the Error I'm encountering in #3 is trivial to fix with this branch: just add the `typographer` plugin to the parser during test, and it seems work!

## To do

- [x] Documentation
- [x] Decide on where/whether this should be included in any default values in the crate