### PR TITLE
Smartquotes

### DIFF
--- a/src/common/utils.rs
+++ b/src/common/utils.rs
@@ -282,6 +282,36 @@ pub fn calc_right_whitespace_with_tabstops(source: &str, mut indent: i32) -> (us
     ( 0, start )
 }
 
+/// Checks whether a given character should count as punctuation
+///
+/// used to determine word boundaries, made to match the implementation of
+/// `isPunctChar` from the JS library.
+/// This is currently implemented as a `match`, but might be simplified as a
+/// regex if benchmarking shows this to be beneficient.
+pub fn is_punct_char(ch: char) -> bool {
+    use unicode_general_category::get_general_category;
+    use unicode_general_category::GeneralCategory::*;
+
+    match get_general_category(ch) {
+        // P
+        ConnectorPunctuation | DashPunctuation | OpenPunctuation | ClosePunctuation |
+        InitialPunctuation | FinalPunctuation | OtherPunctuation => true,
+
+        // L
+        UppercaseLetter | LowercaseLetter | TitlecaseLetter | ModifierLetter | OtherLetter |
+        // M
+        NonspacingMark | SpacingMark | EnclosingMark |
+        // N
+        DecimalNumber | LetterNumber | OtherNumber |
+        // S
+        MathSymbol | CurrencySymbol | ModifierSymbol | OtherSymbol |
+        // Z
+        SpaceSeparator | LineSeparator | ParagraphSeparator |
+        // C
+        Control | Format | Surrogate | PrivateUse | Unassigned => false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::cut_right_whitespace_with_tabstops as cut_ws;

--- a/src/parser/inline/state.rs
+++ b/src/parser/inline/state.rs
@@ -2,6 +2,7 @@
 //
 use crate::{MarkdownIt, Node};
 use crate::common::sourcemap::SourcePos;
+use crate::common::utils::is_punct_char;
 use crate::parser::extset::{InlineRootExtSet, RootExtSet};
 use crate::parser::inline::Text;
 
@@ -19,30 +20,6 @@ pub struct DelimiterRun {
 
     /// Total length of scanned delimiters.
     pub length: usize,
-}
-
-fn is_punct_char(ch: char) -> bool {
-    use unicode_general_category::get_general_category;
-    use unicode_general_category::GeneralCategory::*;
-
-    match get_general_category(ch) {
-        // P
-        ConnectorPunctuation | DashPunctuation | OpenPunctuation | ClosePunctuation |
-        InitialPunctuation | FinalPunctuation | OtherPunctuation => true,
-
-        // L
-        UppercaseLetter | LowercaseLetter | TitlecaseLetter | ModifierLetter | OtherLetter |
-        // M
-        NonspacingMark | SpacingMark | EnclosingMark |
-        // N
-        DecimalNumber | LetterNumber | OtherNumber |
-        // S
-        MathSymbol | CurrencySymbol | ModifierSymbol | OtherSymbol |
-        // Z
-        SpaceSeparator | LineSeparator | ParagraphSeparator |
-        // C
-        Control | Format | Surrogate | PrivateUse | Unassigned => false
-    }
 }
 
 #[derive(Debug)]

--- a/src/parser/node.rs
+++ b/src/parser/node.rs
@@ -103,9 +103,9 @@ impl Node {
 
     /// Execute function `f` recursively on every member of AST tree
     /// (using preorder deep-first search).
-    pub fn walk(&self, mut f: impl FnMut(&Node, u32)) {
+    pub fn walk<'a>(&'a self, mut f: impl FnMut(&'a Node, u32)) {
         // performance note: this is faster than emulating recursion using vec stack
-        fn walk_recursive(node: &Node, depth: u32, f: &mut impl FnMut(&Node, u32)) {
+        fn walk_recursive<'b>(node: &'b Node, depth: u32, f: &mut impl FnMut(&'b Node, u32)) {
             f(node, depth);
             for n in node.children.iter() {
                 stacker::maybe_grow(64*1024, 1024*1024, || {

--- a/src/plugins/cmark/inline/autolink.rs
+++ b/src/plugins/cmark/inline/autolink.rs
@@ -6,7 +6,7 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 use crate::{MarkdownIt, Node, NodeValue, Renderer};
-use crate::parser::inline::{InlineRule, InlineState, Text};
+use crate::parser::inline::{InlineRule, InlineState, TextSpecial};
 
 #[derive(Debug)]
 pub struct Autolink {
@@ -71,7 +71,11 @@ impl InlineRule for AutolinkScanner {
 
         let content = state.md.link_formatter.normalize_link_text(url);
 
-        let mut inner_node = Node::new(Text { content });
+        let mut inner_node = Node::new(TextSpecial {
+            content: content.clone(),
+            markup: content,
+            info: "autolink",
+        });
         inner_node.srcmap = state.get_map(state.pos + 1, pos - 1);
 
         let mut node = Node::new(Autolink { url: full_url });

--- a/src/plugins/extra/linkify.rs
+++ b/src/plugins/extra/linkify.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use crate::parser::core::{CoreRule, Root};
 use crate::parser::extset::RootExt;
 use crate::parser::inline::builtin::InlineParserRule;
-use crate::parser::inline::{InlineRule, InlineState, Text};
+use crate::parser::inline::{InlineRule, InlineState, TextSpecial};
 use crate::{MarkdownIt, Node, NodeValue, Renderer};
 
 static SCHEME_RE : Lazy<Regex> = Lazy::new(|| {
@@ -117,7 +117,11 @@ impl InlineRule for LinkifyScanner {
 
         let content = state.md.link_formatter.normalize_link_text(url);
 
-        let mut inner_node = Node::new(Text { content });
+        let mut inner_node = Node::new(TextSpecial {
+            content: content.clone(),
+            markup: content,
+            info: "autolink",
+        });
         inner_node.srcmap = state.get_map(url_start, url_end);
 
         let mut node = Node::new(Linkified { url: full_url });

--- a/src/plugins/extra/mod.rs
+++ b/src/plugins/extra/mod.rs
@@ -9,6 +9,9 @@
 //!
 //! let html = md.parse("hello ~~world~~").render();
 //! assert_eq!(html.trim(), r#"<p>hello <s>world</s></p>"#);
+//!
+//! let html = md.parse(r#"Markdown done "The Right Way(TM)""#).render();
+//! assert_eq!(html.trim(), r#"<p>Markdown done “The Right Way™”</p>"#);
 //! ```
 pub mod strikethrough;
 pub mod tables;
@@ -30,4 +33,6 @@ pub fn add(md: &mut MarkdownIt) {
     tables::add(md);
     #[cfg(feature = "syntect")]
     syntect::add(md);
+    typographer::add(md);
+    smartquotes::add(md);
 }

--- a/src/plugins/extra/mod.rs
+++ b/src/plugins/extra/mod.rs
@@ -17,6 +17,7 @@ pub mod beautify_links;
 pub mod linkify;
 #[cfg(feature = "syntect")]
 pub mod syntect;
+pub mod typographer;
 
 use crate::MarkdownIt;
 

--- a/src/plugins/extra/mod.rs
+++ b/src/plugins/extra/mod.rs
@@ -15,6 +15,7 @@ pub mod tables;
 pub mod beautify_links;
 #[cfg(feature = "linkify")]
 pub mod linkify;
+pub mod smartquotes;
 #[cfg(feature = "syntect")]
 pub mod syntect;
 pub mod typographer;

--- a/src/plugins/extra/smartquotes.rs
+++ b/src/plugins/extra/smartquotes.rs
@@ -1,0 +1,13 @@
+//! Typography for quotes and apostrophes.
+use crate::parser::core::CoreRule;
+use crate::{MarkdownIt, Node};
+
+pub fn add(md: &mut MarkdownIt) {
+    md.add_rule::<SmartQuotesRule>();
+}
+
+pub struct SmartQuotesRule;
+
+impl CoreRule for SmartQuotesRule {
+    fn run(root: &mut Node, _: &MarkdownIt) {}
+}

--- a/src/plugins/extra/smartquotes.rs
+++ b/src/plugins/extra/smartquotes.rs
@@ -1,13 +1,452 @@
 //! Typography for quotes and apostrophes.
 use crate::parser::core::CoreRule;
+use crate::parser::inline::Text;
+use crate::plugins::cmark::block::paragraph::Paragraph;
+use crate::plugins::cmark::inline::newline::{Hardbreak, Softbreak};
+use crate::plugins::html::html_inline::HtmlInline;
 use crate::{MarkdownIt, Node};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::collections::HashMap;
+
+const APOSTROPHE: char = '\u{2019}';
+const SINGLE_QUOTE: char = '\'';
+const DOUBLE_QUOTE: char = '"';
+const SPACE: char = ' ';
+
+static PUNCTUATION_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\p{Punctuation}").unwrap());
 
 pub fn add(md: &mut MarkdownIt) {
-    md.add_rule::<SmartQuotesRule>();
+    md.add_rule::<SmartQuotesRule<'‘', '’', '“', '”'>>();
 }
 
-pub struct SmartQuotesRule;
+enum FlatToken<'a> {
+    LineBreak,
+    Text {
+        content: &'a str,
+        nesting_level: u32,
+    },
+    Irrelevant,
+}
 
-impl CoreRule for SmartQuotesRule {
-    fn run(root: &mut Node, _: &MarkdownIt) {}
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+enum QuoteType {
+    Single,
+    Double,
+}
+
+struct QuoteMarker {
+    /// The iteration index of the node in which this quote was found
+    walk_index: usize,
+    /// The position within the content string inside the node's `content`
+    quote_position: usize,
+    /// Whether this is a single or a double quote
+    quote_type: QuoteType,
+    /// Nesting level of the containing token
+    level: u32,
+}
+
+struct ReplacementOp {
+    walk_index: usize,
+    quote_position: usize,
+    quote: char,
+}
+
+pub struct SmartQuotesRule<
+    const OPEN_SINGLE_QUOTE: char,
+    const CLOSE_SINGLE_QUOTE: char,
+    const OPEN_DOUBLE_QUOTE: char,
+    const CLOSE_DOUBLE_QUOTE: char,
+>;
+
+impl<
+        const OPEN_SINGLE_QUOTE: char,
+        const CLOSE_SINGLE_QUOTE: char,
+        const OPEN_DOUBLE_QUOTE: char,
+        const CLOSE_DOUBLE_QUOTE: char,
+    > CoreRule
+    for SmartQuotesRule<
+        OPEN_SINGLE_QUOTE,
+        CLOSE_SINGLE_QUOTE,
+        OPEN_DOUBLE_QUOTE,
+        CLOSE_DOUBLE_QUOTE,
+    >
+{
+    fn run(root: &mut Node, _: &MarkdownIt) {
+        let text_tokens = all_text_tokens(root);
+
+        // walk the tree of nodes to figure out what needs replacing where. to
+        // do this, we need to search back and forth over the nodes to find
+        // matching quotes across nodes. The borrow checker won't let us handle
+        // the entire set of nodes as mutable at the same time however, so all
+        // we do here is figure out what we _want_ to replace in which node.
+        let replacement_ops = Self::compute_replacements(text_tokens);
+
+        // now that we know what we want to replace where, we go over the nodes a _third_ time to do all the actual replacements.
+        let mut current_index: usize = 0;
+        root.walk_mut(|node, _| {
+            if let Some(current_replacements) = replacement_ops.get(&current_index) {
+                let mut text_node = node.cast_mut::<Text>().expect("Expected to find a text node at this index because we constructed our replacements HashMap accordingly.");
+                text_node.content = execute_replacements(current_replacements, &text_node.content);
+            };
+            current_index += 1;
+        });
+    }
+}
+
+impl<
+        const OPEN_SINGLE_QUOTE: char,
+        const CLOSE_SINGLE_QUOTE: char,
+        const OPEN_DOUBLE_QUOTE: char,
+        const CLOSE_DOUBLE_QUOTE: char,
+    >
+    SmartQuotesRule<OPEN_SINGLE_QUOTE, CLOSE_SINGLE_QUOTE, OPEN_DOUBLE_QUOTE, CLOSE_DOUBLE_QUOTE>
+{
+    fn compute_replacements(text_tokens: Vec<FlatToken>) -> HashMap<usize, HashMap<usize, char>> {
+        let mut quote_stack: Vec<QuoteMarker> = Vec::new();
+        let mut replacement_ops: HashMap<usize, HashMap<usize, char>> = HashMap::new();
+        for (walk_index, token) in text_tokens.iter().enumerate() {
+            if let FlatToken::Text {
+                content,
+                nesting_level,
+            } = token
+            {
+                for op in Self::replace_smartquotes(
+                    content,
+                    walk_index,
+                    *nesting_level,
+                    &text_tokens,
+                    &mut quote_stack,
+                ) {
+                    replacement_ops
+                        .entry(op.walk_index)
+                        .or_default()
+                        .insert(op.quote_position, op.quote);
+                }
+            }
+        }
+        replacement_ops
+    }
+
+    fn replace_smartquotes(
+        content: &str,
+        walk_index: usize,
+        level: u32,
+        text_tokens: &[FlatToken],
+        quote_stack: &mut Vec<QuoteMarker>,
+    ) -> Vec<ReplacementOp> {
+        truncate_stack(quote_stack, level);
+
+        let mut result: Vec<_> = Vec::new();
+
+        let mut pos: usize = 0;
+
+        'outer: while pos < content.len() {
+            let (quote_position, quote_type) = match find_next_quote(&content, pos) {
+                Some(p) => p,
+                None => {
+                    break 'outer;
+                }
+            };
+
+            pos = quote_position + 1;
+
+            let last_char = find_last_char_before(text_tokens, walk_index, quote_position);
+            let next_char = find_first_char_after(text_tokens, walk_index, quote_position);
+
+            let (can_open, can_close): (bool, bool) =
+                can_open_or_close(&quote_type, last_char, next_char);
+
+            if !can_open && !can_close {
+                // if this is a single quote then we're in the middle of a word and
+                // assume it to be an apostrophe
+                if quote_type == QuoteType::Single {
+                    result.push(ReplacementOp {
+                        walk_index,
+                        quote_position,
+                        quote: APOSTROPHE,
+                    });
+                }
+                // in any case, we're done with this quote and continue searching
+                // for more quotes in this text block
+                continue 'outer;
+            }
+
+            if can_close {
+                for (j, other_item) in quote_stack.iter().enumerate().rev() {
+                    if other_item.level < level {
+                        break;
+                    }
+                    if other_item.quote_type == quote_type && other_item.level == level {
+                        result.push(ReplacementOp {
+                            walk_index: other_item.walk_index,
+                            quote_position: other_item.quote_position,
+                            quote: if quote_type == QuoteType::Single {
+                                OPEN_SINGLE_QUOTE
+                            } else {
+                                OPEN_DOUBLE_QUOTE
+                            },
+                        });
+                        result.push(ReplacementOp {
+                            walk_index,
+                            quote_position,
+                            quote: if quote_type == QuoteType::Single {
+                                CLOSE_SINGLE_QUOTE
+                            } else {
+                                CLOSE_DOUBLE_QUOTE
+                            },
+                        });
+                        quote_stack.truncate(j);
+                        continue 'outer;
+                    }
+                }
+            }
+
+            if can_open {
+                quote_stack.push(QuoteMarker {
+                    walk_index,
+                    quote_position,
+                    quote_type,
+                    level,
+                });
+            } else if can_close && quote_type == QuoteType::Single {
+                result.push(ReplacementOp {
+                    walk_index,
+                    quote_position,
+                    quote: APOSTROPHE,
+                });
+            }
+        }
+        result
+    }
+}
+
+/// Produces a simplified flat list of all tokens, with the necessary
+/// information to handle them later on.
+///
+/// This handles inline html and inline code like JS version seems to do.
+/// This list is a work-around for the fact that we can't build a flat list of
+/// all nodes for iteration back and forth, and at the same time do a mutable
+/// walk on the document tree.
+///
+/// Returns:
+///
+/// TODO: update description
+///  A Vec holding all Text and Newline tokens along with their nesting levels
+///  and indexes, in order of appearance for a pre-order depth-first search.
+fn all_text_tokens(root: &Node) -> Vec<FlatToken> {
+    let mut result = Vec::new();
+    let mut walk_index = 0;
+    root.walk(|node, nesting_level| {
+        if let Some(text_node) = node.cast::<Text>() {
+            result.push(FlatToken::Text {
+                content: &text_node.content,
+                nesting_level,
+            });
+        } else if let Some(html_node) = node.cast::<HtmlInline>() {
+            result.push(FlatToken::Text {
+                content: &html_node.content,
+                nesting_level,
+            });
+        } else if node.is::<Paragraph>() || node.is::<Hardbreak>() || node.is::<Softbreak>() {
+            result.push(FlatToken::LineBreak);
+        } else {
+            result.push(FlatToken::Irrelevant);
+        }
+        walk_index += 1;
+    });
+    result
+}
+
+fn can_open_or_close(quote_type: &QuoteType, last_char: char, next_char: char) -> (bool, bool) {
+    // using `is_ascii_punctuation` here matches the JS version exactly, but
+    // that also means we might inherit that implementation's shortcomings
+    // by ignoring unicode punctuation
+    // Also, the PUNCTUATION_RE uses rust's unicode classes so we rely on
+    // those matching what we want to do. It's not guaranteed to work
+    // exactly 100% like the JS implementation, but in all likelihood the
+    // rust implementation will do *better* in case of differences.
+    let is_last_punctuation =
+        last_char.is_ascii_punctuation() || PUNCTUATION_RE.is_match(&last_char.to_string());
+    let is_next_punctuation =
+        next_char.is_ascii_punctuation() || PUNCTUATION_RE.is_match(&next_char.to_string());
+
+    // Yet again we rely on rust's built-in character handling. The
+    // definition of `is_whitespace` according to the unicode proplist.txt
+    // ( https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt )
+    // shows that the difference to the JS version.
+    //
+    // Not recognized by JS as whitespace but by rust: 0x85, 0x28, 0x29
+    let is_last_whitespace = last_char.is_whitespace();
+    let is_next_whitespace = next_char.is_whitespace();
+
+    let is_double = *quote_type == QuoteType::Double;
+
+    let next_is_double = next_char == DOUBLE_QUOTE;
+
+    let last_is_digit = last_char.is_ascii_digit();
+
+    // TODO: simplify this assignment
+    let mut can_open = true;
+    let mut can_close = true;
+
+    if is_next_whitespace || (is_next_punctuation && !is_last_whitespace && !is_last_punctuation) {
+        can_open = false;
+    }
+
+    if is_last_whitespace || (is_last_punctuation && !is_next_whitespace && !is_next_punctuation) {
+        can_close = false;
+    }
+
+    // special case: 1"" -> count first quote as an inch
+    if next_is_double && is_double && last_is_digit {
+        can_open = false;
+        can_close = false;
+    }
+
+    if can_open && can_close {
+        // Replace quotes in the middle of punctuation sequence, but not
+        // in the middle of the words, i.e.:
+        //
+        // 1. foo " bar " baz - not replaced
+        // 2. foo-"-bar-"-baz - replaced
+        // 3. foo"bar"baz     - not replaced
+        can_open = is_last_punctuation;
+        can_close = is_next_punctuation;
+    }
+
+    (can_open, can_close)
+}
+
+fn execute_replacements(replacement_ops: &HashMap<usize, char>, content: &str) -> String {
+    content
+        .chars()
+        .enumerate()
+        .map(|(i, c)| *replacement_ops.get(&i).unwrap_or(&c))
+        .collect()
+}
+
+/// Truncates the stack of quotes following the JS implementation.
+///
+/// This _might_ be simplified by removing the `rev` call and using
+/// `Vec::take_while` instead, but I'm not 100% sure yet that the levels on the
+/// stack are really monotonously increasing, so I'm leaving it as is for now.
+fn truncate_stack(quote_stack: &mut Vec<QuoteMarker>, level: u32) {
+    let stack_len = quote_stack
+        .iter()
+        .rev()
+        .skip_while(|qm| qm.level > level)
+        .count();
+    quote_stack.truncate(stack_len);
+}
+
+/// Finds the next single or double quote, starting at the given position
+///
+/// This might be replaced with a regex search, but not sure that's really worth
+/// it, given that we only check for two fixed characters.
+fn find_next_quote(content: &str, pos: usize) -> Option<(usize, QuoteType)> {
+    match content
+        .chars()
+        .enumerate()
+        .skip(pos)
+        .find(|(_, c)| *c == SINGLE_QUOTE || *c == DOUBLE_QUOTE)
+    {
+        Some((p, c)) => Some((
+            p,
+            if c == SINGLE_QUOTE {
+                QuoteType::Single
+            } else {
+                QuoteType::Double
+            },
+        )),
+        None => None,
+    }
+}
+
+/// Finds the next relevant character after a given position
+///
+/// This is the mirror image of `find_last_char_before`.
+///
+/// The position given is typically that of a quote we found. It is identified
+/// by its token/node index and the position of the quote inside that token.
+/// The full sequence of the text tokens is searched forwards from that point
+/// and the first character is returned.
+///
+/// If a line break or the end of the document is encountered during search,
+/// space (0x20) is returned.
+///
+/// This function is a bit simpler than `find_last_char_before` because Vec
+/// conveniently returns None for out-of-range indexes at the top end, while not
+/// allowing to index with negative index.
+fn find_first_char_after(
+    text_tokens: &[FlatToken],
+    token_index: usize,
+    quote_position: usize,
+) -> char {
+    for idx_t in token_index..text_tokens.len() {
+        let token = match &text_tokens[idx_t] {
+            FlatToken::LineBreak => return SPACE,
+            FlatToken::Text {
+                content,
+                nesting_level: _,
+            } => content,
+            FlatToken::Irrelevant => continue,
+        };
+        let start_index = if idx_t == token_index {
+            quote_position + 1
+        } else {
+            0
+        };
+        if let Some(c) = token.chars().nth(start_index) {
+            return c;
+        }
+    }
+    // this will be hit if we start searching at the last position of the last
+    // text token
+    SPACE
+}
+
+/// Finds the last relevant character before a given position
+///
+/// The position given is typically that of a quote we found. It is identified
+/// by its token/node index and the position of the quote inside that token.
+/// The full sequence of the text tokens is searched backwards from that point
+/// and the first character is returned.
+///
+/// If a line break or the beginning of the document is encountered during
+/// search, space (0x20) is returned.
+fn find_last_char_before(
+    text_tokens: &[FlatToken],
+    token_index: usize,
+    quote_position: usize,
+) -> char {
+    for idx_t in (0..=token_index).rev() {
+        let token = match &text_tokens[idx_t] {
+            FlatToken::LineBreak => return SPACE,
+            FlatToken::Text {
+                content,
+                nesting_level: _,
+            } => content,
+            FlatToken::Irrelevant => continue,
+        };
+
+        // this is _not_ the first index we want to look at, but rather the
+        // index just _after_ that.  The reason is simply that this is `usize`
+        // and we want to first check if it's possible to still subtract 1 from
+        // it without panicking.
+        let start_index: usize = if idx_t == token_index {
+            quote_position
+        } else {
+            token.len()
+        };
+        if start_index == 0 {
+            continue;
+        }
+        // unwrapping is safe here, we built our index to match the length of
+        // the string, or (in the case of the token containing the quote itself)
+        // it should be indexing a _prefix_ of the string.
+        return token.chars().nth(start_index - 1).unwrap();
+    }
+    // this will be hit if we find a quote in the first position of the first token
+    SPACE
 }

--- a/src/plugins/extra/smartquotes.rs
+++ b/src/plugins/extra/smartquotes.rs
@@ -1,6 +1,8 @@
 //! Replaces `"` and `'` quotes with "nicer" ones like `‘`, `’`, `“`, `”`, or
 //! with `’` for words like "isn't".
 //!
+//! This currently only supports single character quotes, which is a limitation
+//! of the Rust implementation due to the use of `const` generics.
 //!
 //! ## Implementation notes
 //!
@@ -36,8 +38,24 @@ const SINGLE_QUOTE: char = '\'';
 const DOUBLE_QUOTE: char = '"';
 const SPACE: char = ' ';
 
+/// Add smartquotes with the "classic" quote set of `‘`, `’`, `“`, and `”`.
 pub fn add(md: &mut MarkdownIt) {
-    md.add_rule::<SmartQuotesRule<'‘', '’', '“', '”'>>();
+    add_with::<'‘', '’', '“', '”'>(md);
+}
+
+pub fn add_with<
+    const OPEN_SINGLE_QUOTE: char,
+    const CLOSE_SINGLE_QUOTE: char,
+    const OPEN_DOUBLE_QUOTE: char,
+    const CLOSE_DOUBLE_QUOTE: char,
+>(
+    md: &mut MarkdownIt,
+) {
+    md.add_rule::<SmartQuotesRule<
+        OPEN_SINGLE_QUOTE,
+        CLOSE_SINGLE_QUOTE,
+        OPEN_DOUBLE_QUOTE,
+        CLOSE_DOUBLE_QUOTE>>();
 }
 
 /// Simplified Node type that only holds the info we need

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -36,6 +36,8 @@ fn get_replacements() -> &'static Box<[(Regex, &'static str)]> {
             (Regex::new(r"\+-").unwrap(), "±"),
             (Regex::new(r"\.{2,}").unwrap(), "…"),
             (Regex::new(r"([?!])…").unwrap(), "$1.."),
+            (Regex::new(r"([?!]){4,}").unwrap(), "$1$1$1"),
+            (Regex::new(r",{2,}").unwrap(), ","),
         ])
     })
 }

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -1,4 +1,35 @@
 //! Common textual replacements for dashes, ©, ™, …
+//!
+//! **Note:** Since this plugin is most useful with smart-quotes, which is not
+//! currently implemented, this plugin is _not_ enabled by default when using
+//! `plugins::extra::add`. You will have to enable it separately:
+//!
+//! ```rust
+//! let md = &mut markdown_it::MarkdownIt::new();
+//! markdown_it::plugins::cmark::add(md);
+//! markdown_it::plugins::extra::add(md);
+//! markdown_it::plugins::extra::typographer::add(md);
+//!
+//! let html = md.parse("Hello world!.... This is the Right Way(TM) to markdown!!!!!").render();
+//! assert_eq!(html.trim(), r#"<p>Hello world!.. This is the Right Way™ to markdown!!!</p>"#);
+//! ```
+//! In summary, these are the replacements that will be made when using this:
+//!
+//! ## Typography
+//!
+//! - Repeated dots (`...`) to ellipsis (`…`)
+//!   except `?...` and `!...` which become `?..` and `!..` respectively
+//! - `+-` to `±`
+//! - Don't repeat `?` and `!` more than 3 times: `???`
+//! - De-duplicate commas
+//! - em and en dashes: `--` to `–` and `---` to `—`
+//!
+//! ## Common symbols (case insensitive)
+//!
+//! - Copyright: `(c)` to `©`
+//! - Reserved: `(r)` to `®`
+//! - Trademark: `(tm)` to `™`
+
 use crate::parser::core::CoreRule;
 use crate::parser::inline::Text;
 use crate::{MarkdownIt, Node};

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -31,5 +31,11 @@ impl CoreRule for TypographerRule {
 }
 
 fn get_replacements() -> &'static Box<[(Regex, &'static str)]> {
-    REPLACEMENTS.get_or_init(|| Box::new([(Regex::new(r"\+-").unwrap(), "±")]))
+    REPLACEMENTS.get_or_init(|| {
+        Box::new([
+            (Regex::new(r"\+-").unwrap(), "±"),
+            (Regex::new(r"\.{2,}").unwrap(), "…"),
+            (Regex::new(r"([?!])…").unwrap(), "$1.."),
+        ])
+    })
 }

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -1,0 +1,17 @@
+//! Common textual replacements for dashes, ©, ™, …
+use crate::parser::core::CoreRule;
+use crate::parser::inline::Text;
+use crate::{MarkdownIt, Node};
+
+pub fn add(md: &mut MarkdownIt) {
+    md.add_rule::<TypographerRule>();
+}
+
+pub struct TypographerRule;
+impl CoreRule for TypographerRule {
+    fn run(root: &mut Node, _: &MarkdownIt) {
+        root.walk_mut(|node, _| {
+            let content = node.cast::<Text>();
+        });
+    }
+}

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -3,6 +3,11 @@ use crate::parser::core::CoreRule;
 use crate::parser::inline::Text;
 use crate::{MarkdownIt, Node};
 
+use once_cell::sync::OnceCell;
+use regex::Regex;
+
+static REPLACEMENTS: OnceCell<Box<[(Regex, &'static str)]>> = OnceCell::new();
+
 pub fn add(md: &mut MarkdownIt) {
     md.add_rule::<TypographerRule>();
 }
@@ -11,7 +16,20 @@ pub struct TypographerRule;
 impl CoreRule for TypographerRule {
     fn run(root: &mut Node, _: &MarkdownIt) {
         root.walk_mut(|node, _| {
-            let content = node.cast::<Text>();
+            let content = node.cast_mut::<Text>();
+            if let Some(mut text_node) = content {
+                let mut result = text_node.content.to_owned();
+                for (pattern, replacement) in get_replacements().iter() {
+                    result = pattern
+                        .replace_all(&result, replacement.to_string())
+                        .to_string();
+                }
+                text_node.content = result;
+            }
         });
     }
+}
+
+fn get_replacements() -> &'static Box<[(Regex, &'static str)]> {
+    REPLACEMENTS.get_or_init(|| Box::new([(Regex::new(r"\+-").unwrap(), "±")]))
 }

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -20,9 +20,24 @@ impl CoreRule for TypographerRule {
             if let Some(mut text_node) = content {
                 let mut result = text_node.content.to_owned();
                 for (pattern, replacement) in get_replacements().iter() {
-                    result = pattern
-                        .replace_all(&result, replacement.to_string())
-                        .to_string();
+                    // This is a bit unfortunate, but since we can't use
+                    // look-ahead and look-behind patterns in the dash
+                    // replacements, the preceding and following characters (pre
+                    // and post in the patterns) become part of the match.
+                    // So a string like "bla-- --foo" would create two
+                    // *overlapping* matches, "a-- " and " --f". But replace_all
+                    // only replaces non-overlapping matches. So we can't do
+                    // this in one single replacement.
+                    // My only consolation here is that this won't happen very
+                    // often in practice, and in any case it's probably good to
+                    // ask whether the patterns match before attempting any
+                    // replacement, since that's supposed to be the cheaper
+                    // operation.
+                    while pattern.is_match(&result) {
+                        result = pattern
+                            .replace_all(&result, replacement.to_string())
+                            .to_string();
+                    }
                 }
                 text_node.content = result;
             }
@@ -38,6 +53,20 @@ fn get_replacements() -> &'static Box<[(Regex, &'static str)]> {
             (Regex::new(r"([?!])…").unwrap(), "$1.."),
             (Regex::new(r"([?!]){4,}").unwrap(), "$1$1$1"),
             (Regex::new(r",{2,}").unwrap(), ","),
+            // These look a little different from the JS implementation because the
+            // regex crate doesn't support look-behind and look-ahead patterns
+            (
+                Regex::new(r"(?m)(?P<pre>^|[^-])(?P<dash>---)(?P<post>[^-]|$)").unwrap(),
+                "$pre\u{2014}$post",
+            ),
+            (
+                Regex::new(r"(?m)(?P<pre>^|\s)(?P<dash>--)(?P<post>\s|$)").unwrap(),
+                "$pre\u{2013}$post",
+            ),
+            (
+                Regex::new(r"(?m)(?P<pre>^|[^-\s])(?P<dash>--)(?P<post>[^-\s]|$)").unwrap(),
+                "$pre\u{2013}$post",
+            ),
         ])
     })
 }

--- a/src/plugins/extra/typographer.rs
+++ b/src/plugins/extra/typographer.rs
@@ -7,39 +7,60 @@ use once_cell::sync::OnceCell;
 use regex::Regex;
 
 static REPLACEMENTS: OnceCell<Box<[(Regex, &'static str)]>> = OnceCell::new();
+static SCOPED_RE: OnceCell<Regex> = OnceCell::new();
+static RARE_RE: OnceCell<Regex> = OnceCell::new();
+
+fn replace_abbreviation(input: &str) -> &'static str {
+    match input.to_lowercase().as_str() {
+        "(c)" => "©",
+        "(r)" => "®",
+        "(tm)" => "™",
+        _ => unreachable!("Got invalid abbreviation '{}'", input),
+    }
+}
 
 pub fn add(md: &mut MarkdownIt) {
     md.add_rule::<TypographerRule>();
 }
 
 pub struct TypographerRule;
+
 impl CoreRule for TypographerRule {
     fn run(root: &mut Node, _: &MarkdownIt) {
         root.walk_mut(|node, _| {
-            let content = node.cast_mut::<Text>();
-            if let Some(mut text_node) = content {
-                let mut result = text_node.content.to_owned();
-                for (pattern, replacement) in get_replacements().iter() {
-                    // This is a bit unfortunate, but since we can't use
-                    // look-ahead and look-behind patterns in the dash
-                    // replacements, the preceding and following characters (pre
-                    // and post in the patterns) become part of the match.
-                    // So a string like "bla-- --foo" would create two
-                    // *overlapping* matches, "a-- " and " --f". But replace_all
-                    // only replaces non-overlapping matches. So we can't do
-                    // this in one single replacement.
-                    // My only consolation here is that this won't happen very
-                    // often in practice, and in any case it's probably good to
-                    // ask whether the patterns match before attempting any
-                    // replacement, since that's supposed to be the cheaper
-                    // operation.
-                    while pattern.is_match(&result) {
-                        result = pattern
-                            .replace_all(&result, replacement.to_string())
-                            .to_string();
-                    }
+            if let Some(mut text_node) = node.cast_mut::<Text>() {
+                let scoped_re = get_scoped_re();
+                if scoped_re.is_match(&text_node.content) {
+                    text_node.content = scoped_re
+                        .replace_all(&text_node.content, |caps: &regex::Captures| {
+                            replace_abbreviation(caps.get(0).unwrap().as_str())
+                        })
+                        .to_string();
                 }
-                text_node.content = result;
+                if get_rare_re().is_match(&text_node.content) {
+                    let mut result = text_node.content.to_owned();
+                    for (pattern, replacement) in get_replacements().iter() {
+                        // This is a bit unfortunate, but since we can't use
+                        // look-ahead and look-behind patterns in the dash
+                        // replacements, the preceding and following characters (pre
+                        // and post in the patterns) become part of the match.
+                        // So a string like "bla-- --foo" would create two
+                        // *overlapping* matches, "a-- " and " --f". But replace_all
+                        // only replaces non-overlapping matches. So we can't do
+                        // this in one single replacement.
+                        // My only consolation here is that this won't happen very
+                        // often in practice, and in any case it's probably good to
+                        // ask whether the patterns match before attempting any
+                        // replacement, since that's supposed to be the cheaper
+                        // operation.
+                        while pattern.is_match(&result) {
+                            result = pattern
+                                .replace_all(&result, replacement.to_string())
+                                .to_string();
+                        }
+                    }
+                    text_node.content = result;
+                }
             }
         });
     }
@@ -69,4 +90,12 @@ fn get_replacements() -> &'static Box<[(Regex, &'static str)]> {
             ),
         ])
     })
+}
+
+fn get_scoped_re() -> &'static Regex {
+    SCOPED_RE.get_or_init(|| Regex::new(r"(?i)\((c|tm|r)\)").unwrap())
+}
+
+fn get_rare_re() -> &'static Regex {
+    RARE_RE.get_or_init(|| Regex::new(r"\+-|\.\.|\?\?\?\?|!!!!|,,|--").unwrap())
 }

--- a/tests/fixtures/markdown-it/smartquotes.txt
+++ b/tests/fixtures/markdown-it/smartquotes.txt
@@ -1,0 +1,192 @@
+Should parse nested quotes:
+.
+"foo 'bar' baz"
+
+'foo 'bar' baz'
+.
+<p>“foo ‘bar’ baz”</p>
+<p>‘foo ‘bar’ baz’</p>
+.
+
+
+Should not overlap quotes:
+.
+'foo "bar' baz"
+.
+<p>‘foo &quot;bar’ baz&quot;</p>
+.
+
+
+Should match quotes on the same level:
+.
+"foo *bar* baz"
+.
+<p>“foo <em>bar</em> baz”</p>
+.
+
+
+Should handle adjacent nested quotes:
+.
+'"double in single"'
+
+"'single in double'"
+.
+<p>‘“double in single”’</p>
+<p>“‘single in double’”</p>
+.
+
+
+
+Should not match quotes on different levels:
+.
+*"foo* bar"
+
+"foo *bar"*
+
+*"foo* bar *baz"*
+.
+<p><em>&quot;foo</em> bar&quot;</p>
+<p>&quot;foo <em>bar&quot;</em></p>
+<p><em>&quot;foo</em> bar <em>baz&quot;</em></p>
+.
+
+Smartquotes should not overlap with other tags:
+.
+*foo "bar* *baz" quux*
+.
+<p><em>foo &quot;bar</em> <em>baz&quot; quux</em></p>
+.
+
+
+Should try and find matching quote in this case:
+.
+"foo "bar 'baz"
+.
+<p>&quot;foo “bar 'baz”</p>
+.
+
+
+Should not touch 'inches' in quotes:
+.
+"Monitor 21"" and "Monitor""
+.
+<p>“Monitor 21&quot;” and “Monitor”&quot;</p>
+.
+
+
+Should render an apostrophe as a rsquo:
+.
+This isn't and can't be the best approach to implement this...
+.
+<p>This isn’t and can’t be the best approach to implement this…</p>
+.
+
+
+Apostrophe could end the word, that's why original smartypants replaces all of them as rsquo:
+.
+users' stuff
+.
+<p>users’ stuff</p>
+.
+
+Quotes between punctuation chars:
+
+.
+"(hai)".
+.
+<p>“(hai)”.</p>
+.
+
+Quotes at the start/end of the tokens:
+.
+"*foo* bar"
+
+"foo *bar*"
+
+"*foo bar*"
+.
+<p>“<em>foo</em> bar”</p>
+<p>“foo <em>bar</em>”</p>
+<p>“<em>foo bar</em>”</p>
+.
+
+Should treat softbreak as a space:
+.
+"this"
+and "that".
+
+"this" and
+"that".
+.
+<p>“this”
+and “that”.</p>
+<p>“this” and
+“that”.</p>
+.
+
+Should treat hardbreak as a space:
+.
+"this"\
+and "that".
+
+"this" and\
+"that".
+.
+<p>“this”<br>
+and “that”.</p>
+<p>“this” and<br>
+“that”.</p>
+.
+
+Should allow quotes adjacent to other punctuation characters, #643:
+.
+The dog---"'man's' best friend"
+.
+<p>The dog—“‘man’s’ best friend”</p>
+.
+
+Should parse quotes adjacent to code block, #677:
+.
+"test `code`"
+
+"`code` test"
+.
+<p>“test <code>code</code>”</p>
+<p>“<code>code</code> test”</p>
+.
+
+Should parse quotes adjacent to inline html, #677:
+.
+"test <br>"
+
+"<br> test"
+.
+<p>“test <br>”</p>
+<p>“<br> test”</p>
+.
+
+Should be escapable:
+.
+"foo"
+
+\"foo"
+
+"foo\"
+.
+<p>“foo”</p>
+<p>&quot;foo&quot;</p>
+<p>&quot;foo&quot;</p>
+.
+
+Should not replace entities:
+.
+&quot;foo&quot;
+
+&quot;foo"
+
+"foo&quot;
+.
+<p>&quot;foo&quot;</p>
+<p>&quot;foo&quot;</p>
+<p>&quot;foo&quot;</p>
+.

--- a/tests/fixtures/markdown-it/typographer-extra.txt
+++ b/tests/fixtures/markdown-it/typographer-extra.txt
@@ -1,0 +1,6 @@
+don't touch text in autolinks
+.
+URL with (C) (c) (R) (r) (TM) (tm): https://example.com/(c)(r)(tm)/(C)(R)(TM) what do you think?
+.
+<p>URL with © © ® ® ™ ™: <a href="https://example.com/(c)(r)(tm)/(C)(R)(TM)">https://example.com/(c)(r)(tm)/(C)(R)(TM)</a> what do you think?</p>
+.

--- a/tests/fixtures/markdown-it/typographer-extra.txt
+++ b/tests/fixtures/markdown-it/typographer-extra.txt
@@ -4,3 +4,11 @@ URL with (C) (c) (R) (r) (TM) (tm): https://example.com/(c)(r)(tm)/(C)(R)(TM) wh
 .
 <p>URL with © © ® ® ™ ™: <a href="https://example.com/(c)(r)(tm)/(C)(R)(TM)">https://example.com/(c)(r)(tm)/(C)(R)(TM)</a> what do you think?</p>
 .
+
+
+replacements for TM should allow mixed case tM and Tm
+.
+These two should both end up the same as (TM) and (tm): (tM), (Tm).
+.
+<p>These two should both end up the same as ™ and ™: ™, ™.</p>
+.

--- a/tests/fixtures/markdown-it/typographer.txt
+++ b/tests/fixtures/markdown-it/typographer.txt
@@ -1,0 +1,110 @@
+.
+(bad)
+.
+<p>(bad)</p>
+.
+
+
+copyright
+.
+(c) (C)
+.
+<p>© ©</p>
+.
+
+
+reserved
+.
+(r) (R)
+.
+<p>® ®</p>
+.
+
+
+trademark
+.
+(tm) (TM)
+.
+<p>™ ™</p>
+.
+
+
+plus-minus
+.
++-5
+.
+<p>±5</p>
+.
+
+
+ellipsis
+.
+test.. test... test..... test?..... test!....
+.
+<p>test… test… test… test?.. test!..</p>
+.
+
+
+dupes
+.
+!!!!!! ???? ,,
+.
+<p>!!! ??? ,</p>
+.
+
+copyright should be escapable
+.
+\(c)
+.
+<p>(c)</p>
+.
+
+shouldn't replace entities
+.
+&#40;c) (c&#41; (c)
+.
+<p>(c) (c) ©</p>
+.
+
+
+dashes
+.
+---markdownit --- super---
+
+markdownit---awesome
+
+abc ----
+
+--markdownit -- super--
+
+markdownit--awesome
+.
+<p>—markdownit — super—</p>
+<p>markdownit—awesome</p>
+<p>abc ----</p>
+<p>–markdownit – super–</p>
+<p>markdownit–awesome</p>
+.
+
+dashes should be escapable
+.
+foo \-- bar
+
+foo -\- bar
+.
+<p>foo -- bar</p>
+<p>foo -- bar</p>
+.
+
+regression tests for #624
+.
+1---2---3
+
+1--2--3
+
+1 -- -- 3
+.
+<p>1—2—3</p>
+<p>1–2–3</p>
+<p>1 – – 3</p>
+.

--- a/tests/fixtures/testgen.js
+++ b/tests/fixtures/testgen.js
@@ -72,6 +72,7 @@ for (let line of input.split('\n')) {
             let match = line.match(/^\/{2,}\s+TESTGEN:\s*(.+)\s*$/)
             if (match) {
                 let has_data = false
+                lines.push('#[rustfmt::skip]')
                 lines.push(`mod ${ident(match[1])} {`)
                 lines.push('use super::run;')
                 lines.push('// this part of the file is auto-generated')

--- a/tests/markdown-it-smartquotes.rs
+++ b/tests/markdown-it-smartquotes.rs
@@ -1,0 +1,213 @@
+fn run(input: &str, output: &str) {
+    let output = if output.is_empty() {
+        "".to_owned()
+    } else {
+        output.to_owned() + "\n"
+    };
+    let md = &mut markdown_it::MarkdownIt::new();
+    markdown_it::plugins::cmark::add(md);
+    markdown_it::plugins::html::add(md);
+    markdown_it::plugins::extra::linkify::add(md);
+    markdown_it::plugins::extra::typographer::add(md);
+    let node = md.parse(&(input.to_owned() + "\n"));
+
+    // make sure we have sourcemaps for everything
+    node.walk(|node, _| assert!(node.srcmap.is_some()));
+
+    let result = node.render();
+    assert_eq!(result, output);
+
+    // make sure it doesn't crash without trailing \n
+    let _ = md.parse(input.trim_end());
+}
+///////////////////////////////////////////////////////////////////////////
+// TESTGEN: fixtures/markdown-it/smartquotes.txt
+#[rustfmt::skip]
+mod fixtures_markdown_it_smartquotes_txt {
+use super::run;
+// this part of the file is auto-generated
+// don't edit it, otherwise your changes might be lost
+#[test]
+fn should_parse_nested_quotes() {
+    let input = r#""foo 'bar' baz"
+
+'foo 'bar' baz'"#;
+    let output = r#"<p>“foo ‘bar’ baz”</p>
+<p>‘foo ‘bar’ baz’</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_not_overlap_quotes() {
+    let input = r#"'foo "bar' baz""#;
+    let output = r#"<p>‘foo &quot;bar’ baz&quot;</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_match_quotes_on_the_same_level() {
+    let input = r#""foo *bar* baz""#;
+    let output = r#"<p>“foo <em>bar</em> baz”</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_handle_adjacent_nested_quotes() {
+    let input = r#"'"double in single"'
+
+"'single in double'""#;
+    let output = r#"<p>‘“double in single”’</p>
+<p>“‘single in double’”</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_not_match_quotes_on_different_levels() {
+    let input = r#"*"foo* bar"
+
+"foo *bar"*
+
+*"foo* bar *baz"*"#;
+    let output = r#"<p><em>&quot;foo</em> bar&quot;</p>
+<p>&quot;foo <em>bar&quot;</em></p>
+<p><em>&quot;foo</em> bar <em>baz&quot;</em></p>"#;
+    run(input, output);
+}
+
+#[test]
+fn smartquotes_should_not_overlap_with_other_tags() {
+    let input = r#"*foo "bar* *baz" quux*"#;
+    let output = r#"<p><em>foo &quot;bar</em> <em>baz&quot; quux</em></p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_try_and_find_matching_quote_in_this_case() {
+    let input = r#""foo "bar 'baz""#;
+    let output = r#"<p>&quot;foo “bar 'baz”</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_not_touch_inches_in_quotes() {
+    let input = r#""Monitor 21"" and "Monitor"""#;
+    let output = r#"<p>“Monitor 21&quot;” and “Monitor”&quot;</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_render_an_apostrophe_as_a_rsquo() {
+    let input = r#"This isn't and can't be the best approach to implement this..."#;
+    let output = r#"<p>This isn’t and can’t be the best approach to implement this…</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn apostrophe_could_end_the_word_that_s_why_original_smartypants_replaces_all_of_them_as_rsquo() {
+    let input = r#"users' stuff"#;
+    let output = r#"<p>users’ stuff</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn quotes_between_punctuation_chars() {
+    let input = r#""(hai)"."#;
+    let output = r#"<p>“(hai)”.</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn quotes_at_the_start_end_of_the_tokens() {
+    let input = r#""*foo* bar"
+
+"foo *bar*"
+
+"*foo bar*""#;
+    let output = r#"<p>“<em>foo</em> bar”</p>
+<p>“foo <em>bar</em>”</p>
+<p>“<em>foo bar</em>”</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_treat_softbreak_as_a_space() {
+    let input = r#""this"
+and "that".
+
+"this" and
+"that"."#;
+    let output = r#"<p>“this”
+and “that”.</p>
+<p>“this” and
+“that”.</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_treat_hardbreak_as_a_space() {
+    let input = r#""this"\
+and "that".
+
+"this" and\
+"that"."#;
+    let output = r#"<p>“this”<br>
+and “that”.</p>
+<p>“this” and<br>
+“that”.</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_allow_quotes_adjacent_to_other_punctuation_characters_643() {
+    let input = r#"The dog---"'man's' best friend""#;
+    let output = r#"<p>The dog—“‘man’s’ best friend”</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_parse_quotes_adjacent_to_code_block_677() {
+    let input = r#""test `code`"
+
+"`code` test""#;
+    let output = r#"<p>“test <code>code</code>”</p>
+<p>“<code>code</code> test”</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_parse_quotes_adjacent_to_inline_html_677() {
+    let input = r#""test <br>"
+
+"<br> test""#;
+    let output = r#"<p>“test <br>”</p>
+<p>“<br> test”</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_be_escapable() {
+    let input = r#""foo"
+
+\"foo"
+
+"foo\""#;
+    let output = r#"<p>“foo”</p>
+<p>&quot;foo&quot;</p>
+<p>&quot;foo&quot;</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn should_not_replace_entities() {
+    let input = r#"&quot;foo&quot;
+
+&quot;foo"
+
+"foo&quot;"#;
+    let output = r#"<p>&quot;foo&quot;</p>
+<p>&quot;foo&quot;</p>
+<p>&quot;foo&quot;</p>"#;
+    run(input, output);
+}
+// end of auto-generated module
+}

--- a/tests/markdown-it-smartquotes.rs
+++ b/tests/markdown-it-smartquotes.rs
@@ -9,6 +9,7 @@ fn run(input: &str, output: &str) {
     markdown_it::plugins::html::add(md);
     markdown_it::plugins::extra::linkify::add(md);
     markdown_it::plugins::extra::typographer::add(md);
+    markdown_it::plugins::extra::smartquotes::add(md);
     let node = md.parse(&(input.to_owned() + "\n"));
 
     // make sure we have sourcemaps for everything

--- a/tests/markdown-it-typographer.rs
+++ b/tests/markdown-it-typographer.rs
@@ -1,0 +1,135 @@
+fn run(input: &str, output: &str) {
+    let output = if output.is_empty() {
+        "".to_owned()
+    } else {
+        output.to_owned() + "\n"
+    };
+    let md = &mut markdown_it::MarkdownIt::new();
+    markdown_it::plugins::cmark::add(md);
+    markdown_it::plugins::html::add(md);
+    markdown_it::plugins::extra::typographer::add(md);
+    let node = md.parse(&(input.to_owned() + "\n"));
+
+    // make sure we have sourcemaps for everything
+    node.walk(|node, _| assert!(node.srcmap.is_some()));
+
+    let result = node.render();
+    assert_eq!(result, output);
+
+    // make sure it doesn't crash without trailing \n
+    let _ = md.parse(input.trim_end());
+}
+
+///////////////////////////////////////////////////////////////////////////
+// TESTGEN: fixtures/markdown-it/typographer.txt
+#[rustfmt::skip]
+mod fixtures_markdown_it_typographer_txt {
+use super::run;
+// this part of the file is auto-generated
+// don't edit it, otherwise your changes might be lost
+#[test]
+fn unnamed() {
+    let input = r#"(bad)"#;
+    let output = r#"<p>(bad)</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn copyright() {
+    let input = r#"(c) (C)"#;
+    let output = r#"<p>© ©</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn reserved() {
+    let input = r#"(r) (R)"#;
+    let output = r#"<p>® ®</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn trademark() {
+    let input = r#"(tm) (TM)"#;
+    let output = r#"<p>™ ™</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn plus_minus() {
+    let input = r#"+-5"#;
+    let output = r#"<p>±5</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn ellipsis() {
+    let input = r#"test.. test... test..... test?..... test!...."#;
+    let output = r#"<p>test… test… test… test?.. test!..</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn dupes() {
+    let input = r#"!!!!!! ???? ,,"#;
+    let output = r#"<p>!!! ??? ,</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn copyright_should_be_escapable() {
+    let input = r#"\(c)"#;
+    let output = r#"<p>(c)</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn shouldn_t_replace_entities() {
+    let input = r#"&#40;c) (c&#41; (c)"#;
+    let output = r#"<p>(c) (c) ©</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn dashes() {
+    let input = r#"---markdownit --- super---
+
+markdownit---awesome
+
+abc ----
+
+--markdownit -- super--
+
+markdownit--awesome"#;
+    let output = r#"<p>—markdownit — super—</p>
+<p>markdownit—awesome</p>
+<p>abc ----</p>
+<p>–markdownit – super–</p>
+<p>markdownit–awesome</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn dashes_should_be_escapable() {
+    let input = r#"foo \-- bar
+
+foo -\- bar"#;
+    let output = r#"<p>foo -- bar</p>
+<p>foo -- bar</p>"#;
+    run(input, output);
+}
+
+#[test]
+fn regression_tests_for_624() {
+    let input = r#"1---2---3
+
+1--2--3
+
+1 -- -- 3"#;
+    let output = r#"<p>1—2—3</p>
+<p>1–2–3</p>
+<p>1 – – 3</p>"#;
+    run(input, output);
+}
+// end of auto-generated module
+}

--- a/tests/markdown-it-typographer.rs
+++ b/tests/markdown-it-typographer.rs
@@ -33,6 +33,13 @@ fn don_t_touch_text_in_autolinks() {
     let output = r#"<p>URL with © © ® ® ™ ™: <a href="https://example.com/(c)(r)(tm)/(C)(R)(TM)">https://example.com/(c)(r)(tm)/(C)(R)(TM)</a> what do you think?</p>"#;
     run(input, output);
 }
+
+#[test]
+fn replacements_for_tm_should_allow_mixed_case_tm_and_tm() {
+    let input = r#"These two should both end up the same as (TM) and (tm): (tM), (Tm)."#;
+    let output = r#"<p>These two should both end up the same as ™ and ™: ™, ™.</p>"#;
+    run(input, output);
+}
 // end of auto-generated module
 }
 ///////////////////////////////////////////////////////////////////////////

--- a/tests/markdown-it-typographer.rs
+++ b/tests/markdown-it-typographer.rs
@@ -7,6 +7,7 @@ fn run(input: &str, output: &str) {
     let md = &mut markdown_it::MarkdownIt::new();
     markdown_it::plugins::cmark::add(md);
     markdown_it::plugins::html::add(md);
+    markdown_it::plugins::extra::linkify::add(md);
     markdown_it::plugins::extra::typographer::add(md);
     let node = md.parse(&(input.to_owned() + "\n"));
 
@@ -19,7 +20,21 @@ fn run(input: &str, output: &str) {
     // make sure it doesn't crash without trailing \n
     let _ = md.parse(input.trim_end());
 }
-
+///////////////////////////////////////////////////////////////////////////
+// TESTGEN: fixtures/markdown-it/typographer-extra.txt
+#[rustfmt::skip]
+mod fixtures_markdown_it_typographer_extra_txt {
+use super::run;
+// this part of the file is auto-generated
+// don't edit it, otherwise your changes might be lost
+#[test]
+fn don_t_touch_text_in_autolinks() {
+    let input = r#"URL with (C) (c) (R) (r) (TM) (tm): https://example.com/(c)(r)(tm)/(C)(R)(TM) what do you think?"#;
+    let output = r#"<p>URL with © © ® ® ™ ™: <a href="https://example.com/(c)(r)(tm)/(C)(R)(TM)">https://example.com/(c)(r)(tm)/(C)(R)(TM)</a> what do you think?</p>"#;
+    run(input, output);
+}
+// end of auto-generated module
+}
 ///////////////////////////////////////////////////////////////////////////
 // TESTGEN: fixtures/markdown-it/typographer.txt
 #[rustfmt::skip]


### PR DESCRIPTION
This is the follow-up to #4 that I mentioned before, so it includes all of those commits, plus "a few" more. 

I should first say thanks again for reference implementation in JS, wouldn't have been able to do it without. 🙂 

Of course this still needs linting and squashing, and I haven't run it through benchmarking at all. But at least I managed to avoid making string copies all over the place, so that's nice.
I had to add some lifetime annotations to the `walk` function to do that. Is that okay, or do you see a more elegant way to do this?

If you do want to crawl through the unsquashed history here you'll find that the `IT WORKS` commit reads a _lot_ like the JS version. However, I found that to be too long, so I started breaking things out, and the result is actually fairly readable, if I say so myself. 😛