### PR TITLE
make reference maps extensible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ default = ["linkify", "syntect"]
 argparse     = ">= 0.2.1, < 0.3"
 const_format = ">= 0.1.0, < 0.3"
 derivative   = ">= 1.0.2, < 3"
+derive_more  = ">= 0.99.0, < 1"
 downcast-rs  = ">= 1.0.2, < 2"
 entities     = ">= 0.1.0, < 2"
 html-escape  = ">= 0.1.0, < 0.3"


### PR DESCRIPTION
This commit makes it possible to add custom handling for unknown reference labels:

```rs
use markdown_it::parser::block::builtin::BlockParserRule;
use markdown_it::parser::core::{CoreRule, Root};
use markdown_it::plugins::cmark::block::reference::{ReferenceMap, DefaultReferenceMap, CustomReferenceMap};
use markdown_it::{MarkdownIt, Node};

let md = &mut MarkdownIt::new();
markdown_it::plugins::cmark::add(md);

#[derive(Debug, Default)]
struct RefMapOverride(DefaultReferenceMap);
impl CustomReferenceMap for RefMapOverride {
    fn get(&self, label: &str) -> Option<(&str, Option<&str>)> {
        // override a specific link
        if label == "rust" {
            return Some((
                "https://www.rust-lang.org/",
                Some("The Rust Language"),
            ));
        }

        self.0.get(label)
    }

    fn insert(&mut self, label: String, destination: String, title: Option<String>) -> bool {
        self.0.insert(label, destination, title)
    }
}

struct AddCustomReferences;
impl CoreRule for AddCustomReferences {
    fn run(root: &mut Node, _: &MarkdownIt) {
        let data = root.cast_mut::<Root>().unwrap();
        data.ext.insert(ReferenceMap::new(RefMapOverride::default()));
    }
}

md.add_rule::<AddCustomReferences>()
    .before::<BlockParserRule>();

let html = md.parse("[rust]").render();
assert_eq!(
    html.trim(),
    r#"<p><a href="https://www.rust-lang.org/" title="The Rust Language">rust</a></p>"#
);
```