### PR TITLE
Proposal to allow Rule.check to identify the current rule

### DIFF
--- a/src/parser/block/state.rs
+++ b/src/parser/block/state.rs
@@ -42,6 +42,8 @@ pub struct BlockState<'a, 'b> where 'b: 'a {
     pub list_indent: Option<u32>,
 
     pub level: u32,
+
+    pub current_rule: Option<String>,
 }
 
 /// Holds start/end/etc. positions for a specific source text line.
@@ -112,6 +114,7 @@ impl<'a, 'b> BlockState<'a, 'b> {
             tight: false,
             list_indent: None,
             level: 0,
+            current_rule: None,
         };
 
         result.generate_caches();
@@ -170,12 +173,14 @@ impl<'a, 'b> BlockState<'a, 'b> {
     }
 
     #[must_use]
-    pub fn test_rules_at_line(&mut self) -> bool {
+    pub fn test_rules_at_line(&mut self, name: &str) -> bool {
         for rule in self.md.block.ruler.iter() {
+            self.current_rule = Some(name.to_owned());
             if rule.0(self).is_some() {
                 return true;
             }
         }
+        self.current_rule = None;
         false
     }
 

--- a/src/plugins/cmark/block/blockquote.rs
+++ b/src/plugins/cmark/block/blockquote.rs
@@ -117,7 +117,7 @@ impl BlockRule for BlockquoteScanner {
             // Case 3: another tag found.
             state.line = next_line;
 
-            if state.test_rules_at_line() {
+            if state.test_rules_at_line("blockquote") {
                 // Quirk to enforce "hard termination mode" for paragraphs;
                 // normally if you call `nodeize(state, startLine, nextLine)`,
                 // paragraphs will look below nextLine for paragraph continuation,

--- a/src/plugins/cmark/block/lheading.rs
+++ b/src/plugins/cmark/block/lheading.rs
@@ -78,7 +78,7 @@ impl BlockRule for LHeadingScanner {
             // Some tags can terminate paragraph without empty line.
             let old_state_line = state.line;
             state.line = next_line;
-            if state.test_rules_at_line() {
+            if state.test_rules_at_line("lheading") {
                 state.line = old_state_line;
                 break 'outer;
             }

--- a/src/plugins/cmark/block/list.rs
+++ b/src/plugins/cmark/block/list.rs
@@ -331,7 +331,7 @@ impl BlockRule for ListScanner {
             if state.line_indent(next_line) >= 4 { break; }
 
             // fail if terminating block found
-            if state.test_rules_at_line() { break; }
+            if state.test_rules_at_line("list") { break; }
 
             current_line = state.get_line(state.line).to_owned();
 

--- a/src/plugins/cmark/block/paragraph.rs
+++ b/src/plugins/cmark/block/paragraph.rs
@@ -52,7 +52,7 @@ impl BlockRule for ParagraphScanner {
             // Some tags can terminate paragraph without empty line.
             let old_state_line = state.line;
             state.line = next_line;
-            if state.test_rules_at_line() {
+            if state.test_rules_at_line("paragraph") {
                 state.line = old_state_line;
                 break 'outer;
             }

--- a/src/plugins/cmark/block/reference.rs
+++ b/src/plugins/cmark/block/reference.rs
@@ -246,7 +246,7 @@ impl BlockRule for ReferenceScanner {
             // Some tags can terminate paragraph without empty line.
             let old_state_line = state.line;
             state.line = next_line;
-            if state.test_rules_at_line() {
+            if state.test_rules_at_line("reference") {
                 state.line = old_state_line;
                 break 'outer;
             }

--- a/src/plugins/extra/tables.rs
+++ b/src/plugins/extra/tables.rs
@@ -352,7 +352,7 @@ impl BlockRule for TableScanner {
             if state.is_empty(state.line) { break; }
 
             // fail if terminating block found
-            if state.test_rules_at_line() { break; }
+            if state.test_rules_at_line("table") { break; }
 
             let mut row_node = Node::new(TableRow);
             row_node.srcmap = state.get_map(state.line, state.line);


### PR DESCRIPTION
In markdown-it JS, via the `alt` list,
you could specify that a rule interrupted another block, only for certain block types.

This is a rough proposal to re-implement that feature, such that an implementation of `Rule.check` could identify what the current rule was.

Currently, I'm just setting a string name on the `BlockState`, as this was the least intrusive way (i.e. does not require a change in the signature of check). But perhaps there is a nicer way?