### PR TITLE
Add support for class-based highlighting

### DIFF
--- a/src/plugins/extra/syntect.rs
+++ b/src/plugins/extra/syntect.rs
@@ -63,10 +63,7 @@ impl CoreRule for SyntectRule {
     fn run(root: &mut Node, md: &MarkdownIt) {
         let ss = SyntaxSet::load_defaults_newlines();
         let ts = ThemeSet::load_defaults();
-        let mode = match md.ext.get::<SyntectSettings>().copied().unwrap_or_default().0 {
-            SyntectMode::InlineStyles {theme} => Some(&ts.themes[theme]),
-            SyntectMode::CssClasses => None
-        };
+        let mode = match md.ext.get::<SyntectSettings>().copied().unwrap_or_default().0;
 
         root.walk_mut(|node, _| {
             let mut content = None;


### PR DESCRIPTION
I have a use case where I would like to use CSS for highlighting, since that would allow automatically switching between light/dark themes.

This adds a mode that should use CSS based theming.